### PR TITLE
Typescipt generator, preventing circular dependency due to barrel import

### DIFF
--- a/rxrpc-apt-typescript/src/main/java/com/slimgears/rxrpc/apt/typescript/TypeScriptUtils.java
+++ b/rxrpc-apt-typescript/src/main/java/com/slimgears/rxrpc/apt/typescript/TypeScriptUtils.java
@@ -81,19 +81,26 @@ public class TypeScriptUtils extends TemplateUtils {
                     String packagePath = Optional
                             .of(camelCaseToDash(entry.getKey()).replace('.', '/'))
                             .filter(str -> !str.isEmpty())
-                            .orElse("./index");
+                            .orElse(null);
 
-                    if (packagePath.startsWith("/")) {
-                        packagePath = "." + packagePath;
+                    if (packagePath != null) {
+                        if (packagePath.startsWith("/")) {
+                            packagePath = "." + packagePath;
+                        }
+                        return entry.getValue()
+                                .stream()
+                                .sorted()
+                                .collect(Collectors.joining(
+                                        ", ",
+                                        "import { ",
+                                        " } from '" + packagePath.replace("___at___", "@") + "';"));
+                    } else {
+                        return entry.getValue()
+                                .stream()
+                                .sorted()
+                                .map(el -> "import { "  + el + " } from './" + camelCaseToDash(el) + "';")
+                                .collect(Collectors.joining("\n"));
                     }
-
-                    return entry.getValue()
-                            .stream()
-                            .sorted()
-                            .collect(Collectors.joining(
-                                    ", ",
-                                    "import { ",
-                                    " } from '" + packagePath.replace("___at___", "@") + "';"));
                 })
                 .collect(Collectors.joining("\n"));
         return code.replace(importTracker.toString(), importsStr);

--- a/rxrpc-apt-typescript/src/test/resources/output/module.ts
+++ b/rxrpc-apt-typescript/src/test/resources/output/module.ts
@@ -1,6 +1,6 @@
 import {InjectionToken, ModuleWithProviders, NgModule, Type} from '@angular/core';
 import {RxRpcClient, RxRpcInvoker, RxRpcTransport} from 'rxrpc-js';
-import { SampleEndpointClient } from './sample-endpoint-client';
+import {SampleEndpointClient} from './sample-endpoint-client';
 
 @NgModule({
     providers: [

--- a/rxrpc-apt-typescript/src/test/resources/output/sample-array-endpoint.ts
+++ b/rxrpc-apt-typescript/src/test/resources/output/sample-array-endpoint.ts
@@ -1,4 +1,5 @@
-import { SampleArray, SampleData } from './index';
+import { SampleArray } from './sample-array';
+import { SampleData } from './sample-data';
 import { Observable } from 'rxjs';
 
 /**

--- a/rxrpc-apt-typescript/src/test/resources/output/sample-base-endpoint.ts
+++ b/rxrpc-apt-typescript/src/test/resources/output/sample-base-endpoint.ts
@@ -1,4 +1,4 @@
-import { SampleRequest } from './index';
+import { SampleRequest } from './sample-request';
 import { Observable } from 'rxjs';
 
 /**

--- a/rxrpc-apt-typescript/src/test/resources/output/sample-circular-reference-endpoint.ts
+++ b/rxrpc-apt-typescript/src/test/resources/output/sample-circular-reference-endpoint.ts
@@ -1,4 +1,4 @@
-import { SampleCircularReferenceData } from './index';
+import { SampleCircularReferenceData } from './sample-circular-reference-data';
 import { Observable } from 'rxjs';
 
 /**

--- a/rxrpc-apt-typescript/src/test/resources/output/sample-data.ts
+++ b/rxrpc-apt-typescript/src/test/resources/output/sample-data.ts
@@ -1,4 +1,5 @@
-import { SampleEnum, SampleGenericData } from './index';
+import { SampleEnum } from './sample-enum';
+import { SampleGenericData } from './sample-generic-data';
 
 /**
  * Generated from com.slimgears.rxrpc.sample.SampleData

--- a/rxrpc-apt-typescript/src/test/resources/output/sample-default-name-endpoint-client.ts
+++ b/rxrpc-apt-typescript/src/test/resources/output/sample-default-name-endpoint-client.ts
@@ -1,4 +1,4 @@
-import { SampleDefaultNameEndpoint } from './index';
+import { SampleDefaultNameEndpoint } from './sample-default-name-endpoint';
 import { FactoryProvider, Injectable, InjectionToken, Type } from '@angular/core';
 import { Observable } from 'rxjs';
 import { RxRpcInvoker } from 'rxrpc-js';

--- a/rxrpc-apt-typescript/src/test/resources/output/sample-derived-data.ts
+++ b/rxrpc-apt-typescript/src/test/resources/output/sample-derived-data.ts
@@ -1,4 +1,4 @@
-import { SampleBaseData } from './index';
+import { SampleBaseData } from './sample-base-data';
 
 /**
  * Generated from com.slimgears.rxrpc.sample.SampleDerivedData

--- a/rxrpc-apt-typescript/src/test/resources/output/sample-endpoint-client.ts
+++ b/rxrpc-apt-typescript/src/test/resources/output/sample-endpoint-client.ts
@@ -1,4 +1,7 @@
-import { SampleArray, SampleData, SampleEndpoint, SampleRequest } from './index';
+import { SampleArray } from './sample-array';
+import { SampleData } from './sample-data';
+import { SampleEndpoint } from './sample-endpoint';
+import { SampleRequest } from './sample-request';
 import { FactoryProvider, Injectable, InjectionToken, Type } from '@angular/core';
 import { Observable } from 'rxjs';
 import { RxRpcInvoker } from 'rxrpc-js';

--- a/rxrpc-apt-typescript/src/test/resources/output/sample-endpoint.ts
+++ b/rxrpc-apt-typescript/src/test/resources/output/sample-endpoint.ts
@@ -1,4 +1,7 @@
-import { SampleArrayEndpoint, SampleBaseEndpoint, SampleData, SampleRequest } from './index';
+import { SampleArrayEndpoint } from './sample-array-endpoint';
+import { SampleBaseEndpoint } from './sample-base-endpoint';
+import { SampleData } from './sample-data';
+import { SampleRequest } from './sample-request';
 import { Observable } from 'rxjs';
 
 /**

--- a/rxrpc-apt-typescript/src/test/resources/output/sample-generic-endpoint.ts
+++ b/rxrpc-apt-typescript/src/test/resources/output/sample-generic-endpoint.ts
@@ -1,4 +1,5 @@
-import { SampleGenericData, SampleGenericList } from './index';
+import { SampleGenericData } from './sample-generic-data';
+import { SampleGenericList } from './sample-generic-list';
 import { Observable } from 'rxjs';
 
 /**

--- a/rxrpc-apt-typescript/src/test/resources/output/sample-generic-list.ts
+++ b/rxrpc-apt-typescript/src/test/resources/output/sample-generic-list.ts
@@ -1,4 +1,4 @@
-import { SampleGenericData } from './index';
+import { SampleGenericData } from './sample-generic-data';
 
 /**
  * Generated from com.slimgears.rxrpc.sample.SampleGenericList

--- a/rxrpc-apt-typescript/src/test/resources/output/sample-map-data.ts
+++ b/rxrpc-apt-typescript/src/test/resources/output/sample-map-data.ts
@@ -1,4 +1,4 @@
-import { SampleData } from './index';
+import { SampleData } from './sample-data';
 import { StringKeyMap } from 'rxrpc-js';
 
 /**

--- a/rxrpc-apt-typescript/src/test/resources/output/sample-map-endpoint-client.ts
+++ b/rxrpc-apt-typescript/src/test/resources/output/sample-map-endpoint-client.ts
@@ -1,4 +1,5 @@
-import { SampleMapData, SampleMapEndpoint } from './index';
+import { SampleMapData } from './sample-map-data';
+import { SampleMapEndpoint } from './sample-map-endpoint';
 import { FactoryProvider, Injectable, InjectionToken, Type } from '@angular/core';
 import { Observable } from 'rxjs';
 import { RxRpcInvoker, StringKeyMap } from 'rxrpc-js';

--- a/rxrpc-apt-typescript/src/test/resources/output/sample-map-endpoint.ts
+++ b/rxrpc-apt-typescript/src/test/resources/output/sample-map-endpoint.ts
@@ -1,4 +1,4 @@
-import { SampleMapData } from './index';
+import { SampleMapData } from './sample-map-data';
 import { Observable } from 'rxjs';
 import { StringKeyMap } from 'rxrpc-js';
 

--- a/rxrpc-apt-typescript/src/test/resources/output/sample-nested-data-endpoint-client.ts
+++ b/rxrpc-apt-typescript/src/test/resources/output/sample-nested-data-endpoint-client.ts
@@ -1,4 +1,5 @@
-import { SampleNestedDataEndpoint, SampleNestedDataEndpointData } from './index';
+import { SampleNestedDataEndpoint } from './sample-nested-data-endpoint';
+import { SampleNestedDataEndpointData } from './sample-nested-data-endpoint-data';
 import { FactoryProvider, Injectable, InjectionToken, Type } from '@angular/core';
 import { Observable } from 'rxjs';
 import { RxRpcInvoker } from 'rxrpc-js';

--- a/rxrpc-apt-typescript/src/test/resources/output/sample-nested-data-endpoint-data.ts
+++ b/rxrpc-apt-typescript/src/test/resources/output/sample-nested-data-endpoint-data.ts
@@ -1,4 +1,4 @@
-import { SampleNestedDataEndpointDataType } from './index';
+import { SampleNestedDataEndpointDataType } from './sample-nested-data-endpoint-data-type';
 
 /**
  * Generated from com.slimgears.rxrpc.sample.SampleNestedDataEndpoint$Data

--- a/rxrpc-apt-typescript/src/test/resources/output/sample-nested-data-endpoint.ts
+++ b/rxrpc-apt-typescript/src/test/resources/output/sample-nested-data-endpoint.ts
@@ -1,4 +1,4 @@
-import { SampleNestedDataEndpointData } from './index';
+import { SampleNestedDataEndpointData } from './sample-nested-data-endpoint-data';
 import { Observable } from 'rxjs';
 
 /**

--- a/rxrpc-apt-typescript/src/test/resources/output/sample-optional-data.ts
+++ b/rxrpc-apt-typescript/src/test/resources/output/sample-optional-data.ts
@@ -1,4 +1,4 @@
-import { SampleEnum } from './index';
+import { SampleEnum } from './sample-enum';
 
 /**
  * Generated from com.slimgears.rxrpc.sample.SampleOptionalData

--- a/rxrpc-apt-typescript/src/test/resources/output/sample-request.ts
+++ b/rxrpc-apt-typescript/src/test/resources/output/sample-request.ts
@@ -1,4 +1,4 @@
-import { SampleData } from './index';
+import { SampleData } from './sample-data';
 import { StringKeyMap } from 'rxrpc-js';
 
 /**

--- a/rxrpc-apt-typescript/src/test/resources/output/sample-specialized-endpoint-client.ts
+++ b/rxrpc-apt-typescript/src/test/resources/output/sample-specialized-endpoint-client.ts
@@ -1,4 +1,7 @@
-import { SampleGenericData, SampleGenericList, SampleSpecializedData, SampleSpecializedEndpoint } from './index';
+import { SampleGenericData } from './sample-generic-data';
+import { SampleGenericList } from './sample-generic-list';
+import { SampleSpecializedData } from './sample-specialized-data';
+import { SampleSpecializedEndpoint } from './sample-specialized-endpoint';
 import { FactoryProvider, Injectable, InjectionToken, Type } from '@angular/core';
 import { Observable } from 'rxjs';
 import { RxRpcInvoker } from 'rxrpc-js';

--- a/rxrpc-apt-typescript/src/test/resources/output/sample-specialized-endpoint.ts
+++ b/rxrpc-apt-typescript/src/test/resources/output/sample-specialized-endpoint.ts
@@ -1,4 +1,5 @@
-import { SampleGenericEndpoint, SampleSpecializedData } from './index';
+import { SampleGenericEndpoint } from './sample-generic-endpoint';
+import { SampleSpecializedData } from './sample-specialized-data';
 import { Observable } from 'rxjs';
 
 /**


### PR DESCRIPTION
For preventing import from itself, imports from './' generated like './<source-file>'